### PR TITLE
change bean name metricRegistry to mfMetricRegistry to avoid possible conflicts with 3rd-party configurations with the same name.

### DIFF
--- a/metrics-facade-spring/metrics-facade-spring-boot-autoconfigure/src/main/java/com/ringcentral/platform/metrics/spring/MfMetricsExportAutoConfiguration.java
+++ b/metrics-facade-spring/metrics-facade-spring-boot-autoconfigure/src/main/java/com/ringcentral/platform/metrics/spring/MfMetricsExportAutoConfiguration.java
@@ -37,7 +37,7 @@ public class MfMetricsExportAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public MetricRegistry metricRegistry(
+    public MetricRegistry mfMetricRegistry(
         MetricRegistryMaker maker,
         List<MetricRegistryCustomizer> customizers,
         List<MetricRegistryListener> listeners) {


### PR DESCRIPTION
change bean name metricRegistry to mfMetricRegistry to avoid possible conflicts with 3rd-party configurations with the same name.