### PR TITLE
#75: Fix concurrency issues related to the incorrect usage of LongAdders

### DIFF
--- a/metrics-facade-base/src/main/java/com/ringcentral/platform/metrics/histogram/Histogram.java
+++ b/metrics-facade-base/src/main/java/com/ringcentral/platform/metrics/histogram/Histogram.java
@@ -6,6 +6,7 @@ import com.ringcentral.platform.metrics.measurables.MeasurableType;
 import com.ringcentral.platform.metrics.scale.Scale;
 import com.ringcentral.platform.metrics.scale.ScaleBuilder;
 
+import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -441,7 +442,7 @@ public interface Histogram extends Meter {
         }
 
         @Override
-        public int compareTo(Bucket right) {
+        public int compareTo(@Nonnull Bucket right) {
             if (isInf()) {
                 return right.isInf() ? 0 : 1;
             }

--- a/metrics-facade-benchmark/src/main/java/com/ringcentral/platform/metrics/benchmark/histogram/ConsistentTotalsBasicConsistencyCheckBenchmark.java
+++ b/metrics-facade-benchmark/src/main/java/com/ringcentral/platform/metrics/benchmark/histogram/ConsistentTotalsBasicConsistencyCheckBenchmark.java
@@ -36,7 +36,7 @@ public class ConsistentTotalsBasicConsistencyCheckBenchmark {
         }
     }
 
-    public static class SixteenThreads {
+    public static class Driver {
         public static void main(String[] args) {
             Options options = new OptionsBuilder()
                 .include(ConsistentTotalsBasicConsistencyCheckBenchmark.class.getSimpleName())

--- a/metrics-facade-benchmark/src/main/java/com/ringcentral/platform/metrics/benchmark/histogram/ConsistentTotalsBasicConsistencyCheckBenchmark.java
+++ b/metrics-facade-benchmark/src/main/java/com/ringcentral/platform/metrics/benchmark/histogram/ConsistentTotalsBasicConsistencyCheckBenchmark.java
@@ -1,0 +1,56 @@
+package com.ringcentral.platform.metrics.benchmark.histogram;
+
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.totals.ConsistentTotalsHistogramImpl;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.*;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode({ Mode.Throughput, Mode.AverageTime })
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class ConsistentTotalsBasicConsistencyCheckBenchmark {
+
+    @org.openjdk.jmh.annotations.State(Scope.Benchmark)
+    public static class State {
+        final ConsistentTotalsHistogramImpl totals = new ConsistentTotalsHistogramImpl();
+    }
+
+    @Group("writeReadNoDelays")
+    @GroupThreads(8)
+    @Benchmark
+    public void write(State state) {
+        state.totals.update(1);
+    }
+
+    @Group("writeReadNoDelays")
+    @GroupThreads(4)
+    @Benchmark
+    public void read(State state) {
+        HistogramSnapshot snapshot = state.totals.snapshot();
+
+        if (snapshot.count() != snapshot.totalSum()) {
+            throw new IllegalStateException("Snapshot is not consistent");
+        }
+    }
+
+    public static class SixteenThreads {
+        public static void main(String[] args) {
+            Options options = new OptionsBuilder()
+                .include(ConsistentTotalsBasicConsistencyCheckBenchmark.class.getSimpleName())
+                .warmupIterations(2)
+                .measurementIterations(5)
+                .measurementTime(TimeValue.minutes(1L))
+                .threads(12)
+                .forks(1)
+                .build();
+            try {
+                new Runner(options).run();
+            } catch (RunnerException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/metrics-facade-benchmark/src/main/java/com/ringcentral/platform/metrics/benchmark/histogram/ConsistentTotalsSnapshotThreadOnSpinWaitBenchmark.java
+++ b/metrics-facade-benchmark/src/main/java/com/ringcentral/platform/metrics/benchmark/histogram/ConsistentTotalsSnapshotThreadOnSpinWaitBenchmark.java
@@ -1,0 +1,93 @@
+package com.ringcentral.platform.metrics.benchmark.histogram;
+
+import com.ringcentral.platform.metrics.defaultImpl.histogram.totals.ConsistentTotalsHistogramImpl;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.*;
+
+import java.util.concurrent.locks.LockSupport;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+
+/**
+ * We did not observe any significant performance difference, but
+ * {@link Thread#onSpinWait()} is the recommended hint for busy-wait
+ * loops, so we chose to leave it enabled.
+ */
+@BenchmarkMode({ Mode.AverageTime, Mode.SampleTime, Mode.Throughput })
+@OutputTimeUnit(MICROSECONDS)
+public class ConsistentTotalsSnapshotThreadOnSpinWaitBenchmark {
+
+    public static class NoOpOnSpinWaitImpl extends ConsistentTotalsHistogramImpl {
+
+        @Override
+        protected void onSpinWaitImpl() {}
+    }
+
+    public static final int WRITER_THREAD_COUNT = 11;
+    public static final int READER_THREAD_COUNT = 1;
+
+    // 55 µs -> ~18k updates/s per writer -> up to ~200k in total with 11 writers
+    public static final long WRITER_PAUSE = MICROSECONDS.toNanos(1) * 5 * WRITER_THREAD_COUNT;
+
+    // 1 µs pause -> up to ~1m snapshots/s with a single reader
+    public static final long READER_PAUSE = MICROSECONDS.toNanos(1) * READER_THREAD_COUNT;
+
+    @org.openjdk.jmh.annotations.State(Scope.Benchmark)
+    public static class State {
+        final ConsistentTotalsHistogramImpl baseImpl = new ConsistentTotalsHistogramImpl();
+        final NoOpOnSpinWaitImpl noOpOnSpinWaitImpl = new NoOpOnSpinWaitImpl();
+    }
+
+    @Benchmark
+    @Group("baseImpl")
+    @GroupThreads(11)
+    public void baseImpl_Write(State state) {
+        state.baseImpl.update(1);
+        LockSupport.parkNanos(WRITER_PAUSE);
+    }
+
+    @Benchmark
+    @Group("baseImpl")
+    @GroupThreads(1)
+    public void baseImpl_Read(State state) {
+        state.baseImpl.snapshot();
+        LockSupport.parkNanos(READER_PAUSE);
+    }
+
+    @Benchmark
+    @Group("noOpOnSpinWaitImpl")
+    @GroupThreads(11)
+    public void noOpOnSpinWaitImpl_Write(State state) {
+        state.noOpOnSpinWaitImpl.update(1);
+        LockSupport.parkNanos(WRITER_PAUSE);
+    }
+
+    @Benchmark
+    @Group("noOpOnSpinWaitImpl")
+    @GroupThreads(1)
+    public void noOpOnSpinWaitImpl_Read(State state) {
+        state.noOpOnSpinWaitImpl.snapshot();
+        LockSupport.parkNanos(READER_PAUSE);
+    }
+
+    public static class Driver {
+        public static void main(String[] args) {
+            Options options = new OptionsBuilder()
+                .include(ConsistentTotalsSnapshotThreadOnSpinWaitBenchmark.class.getSimpleName())
+                .warmupIterations(1)
+                .measurementIterations(2)
+                .syncIterations(false)
+                .measurementTime(TimeValue.minutes(1))
+                .threads(12)
+                .forks(1)
+                .build();
+            try {
+                new Runner(options).run();
+            } catch (RunnerException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/configs/AbstractHistogramImplConfigBuilder.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/configs/AbstractHistogramImplConfigBuilder.java
@@ -1,10 +1,12 @@
 package com.ringcentral.platform.metrics.defaultImpl.histogram.configs;
 
+import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 import static com.ringcentral.platform.metrics.defaultImpl.histogram.configs.HistogramImplConfig.*;
+import static com.ringcentral.platform.metrics.defaultImpl.histogram.configs.TotalsMeasurementType.*;
 import static com.ringcentral.platform.metrics.utils.Preconditions.checkArgument;
 
 @SuppressWarnings({ "ConstantConditions", "OptionalUsedAsFieldOrParameterType", "unchecked" })
@@ -17,12 +19,15 @@ public abstract class AbstractHistogramImplConfigBuilder<
     protected Optional<Duration> snapshotTtl = Optional.ofNullable(DEFAULT_SNAPSHOT_TTL);
 
     public CB consistentTotals() {
-        this.totalsMeasurementType = TotalsMeasurementType.CONSISTENT;
-        return builder();
+        return totals(CONSISTENT);
     }
 
     public CB eventuallyConsistentTotals() {
-        this.totalsMeasurementType = TotalsMeasurementType.EVENTUALLY_CONSISTENT;
+        return totals(EVENTUALLY_CONSISTENT);
+    }
+
+    public CB totals(@Nonnull TotalsMeasurementType type) {
+        this.totalsMeasurementType = type;
         return builder();
     }
 

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/internal/DefaultMultiScaleTreeNode.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/internal/DefaultMultiScaleTreeNode.java
@@ -54,17 +54,6 @@ public class DefaultMultiScaleTreeNode implements MultiScaleTreeNode {
     }
 
     @Override
-    public boolean hasLeft() {
-        for (int i = 0; i < chunkCount; ++i) {
-            if (nodes[i] != null && nodes[i].left != null) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    @Override
     public void toLeft() {
         for (int i = 0; i < chunkCount; ++i) {
             if (nodes[i] != null) {
@@ -84,17 +73,6 @@ public class DefaultMultiScaleTreeNode implements MultiScaleTreeNode {
         }
 
         return result;
-    }
-
-    @Override
-    public boolean hasRight() {
-        for (int i = 0; i < chunkCount; ++i) {
-            if (nodes[i] != null && nodes[i].right != null) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     @Override

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/internal/DoubleScaleTreeNode.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/internal/DoubleScaleTreeNode.java
@@ -58,11 +58,6 @@ public class DoubleScaleTreeNode implements MultiScaleTreeNode {
     }
 
     @Override
-    public boolean hasLeft() {
-        return (node1 != null && node1.left != null) || (node2 != null && node2.left != null);
-    }
-
-    @Override
     public void toLeft() {
         if (node1 != null) {
             node1 = node1.left;
@@ -86,11 +81,6 @@ public class DoubleScaleTreeNode implements MultiScaleTreeNode {
         }
 
         return result;
-    }
-
-    @Override
-    public boolean hasRight() {
-        return (node1 != null && node1.right != null) || (node2 != null && node2.right != null);
     }
 
     @Override

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/internal/MultiScaleTreeNode.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/internal/MultiScaleTreeNode.java
@@ -9,11 +9,9 @@ public interface MultiScaleTreeNode {
     boolean isNull();
     long subtreeUpdateCount();
 
-    boolean hasLeft();
     void toLeft();
     long leftSubtreeUpdateCount();
 
-    boolean hasRight();
     void toRight();
     long rightSubtreeUpdateCount();
 }

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/internal/ScaleTreeNode.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/internal/ScaleTreeNode.java
@@ -15,7 +15,7 @@ public class ScaleTreeNode {
     public int levelOrderIndex;
 
     public final AtomicLong updateEpoch;
-    public final LongAdder subtreeUpdateCount = new LongAdder();
+    public final AtomicLong subtreeUpdateCount = new AtomicLong();
 
     public final AtomicLong snapshotNum = new AtomicLong(INITIAL_SNAPSHOT_NUM);
     public volatile long snapshotSubtreeUpdateCount = Long.MIN_VALUE;

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/neverReset/NeverResetChunk.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/neverReset/NeverResetChunk.java
@@ -14,7 +14,7 @@ public class NeverResetChunk extends Chunk {
     protected void updateTree(ScaleTreeNode node, boolean snapshotInProgress, long snapshotNum) {
         while (node != null) {
             if (snapshotInProgress && node.snapshotNum.get() < snapshotNum) {
-                long subtreeUpdateCount = node.subtreeUpdateCount.sum();
+                long subtreeUpdateCount = node.subtreeUpdateCount.get();
 
                 if (node.snapshotNum.get() < snapshotNum) {
                     node.snapshotSubtreeUpdateCount = subtreeUpdateCount;
@@ -22,7 +22,7 @@ public class NeverResetChunk extends Chunk {
                 }
             }
 
-            node.subtreeUpdateCount.increment();
+            node.subtreeUpdateCount.incrementAndGet();
 
             if (node.level > upperLazyTreeLevel) {
                 node = node.parent;
@@ -42,7 +42,7 @@ public class NeverResetChunk extends Chunk {
             return lazySubtreeUpdateCountFor(node);
         }
 
-        long nodeSubtreeUpdateCount = node.subtreeUpdateCount.sum();
+        long nodeSubtreeUpdateCount = node.subtreeUpdateCount.get();
         long nodeSnapshotNum = node.snapshotNum.get();
 
         return

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/resetByChunks/ResetByChunksChunk.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/resetByChunks/ResetByChunksChunk.java
@@ -12,7 +12,7 @@ public class ResetByChunksChunk extends Chunk {
 
     @Override
     protected void updateTree(ScaleTreeNode node, boolean snapshotInProgress, long snapshotNum) {
-        long nodeSubtreeUpdateCount = node.subtreeUpdateCount.sum();
+        long nodeSubtreeUpdateCount = node.subtreeUpdateCount.get();
         long nodeUpdateEpoch = node.updateEpoch.get();
         long treeUpdateEpoch = tree.updateEpoch;
 
@@ -21,22 +21,22 @@ public class ResetByChunksChunk extends Chunk {
                 if (treeUpdateEpoch == nodeUpdateEpoch) {
                     node.snapshotSubtreeUpdateCount = nodeSubtreeUpdateCount;
                     node.snapshotNum.set(snapshotNum);
-                    node.subtreeUpdateCount.increment();
+                    node.subtreeUpdateCount.incrementAndGet();
                 } else {
                     node.snapshotSubtreeUpdateCount = 0L;
                     node.snapshotNum.set(snapshotNum);
 
                     if (node.updateEpoch.compareAndSet(nodeUpdateEpoch, treeUpdateEpoch)) {
-                        node.subtreeUpdateCount.add(-nodeSubtreeUpdateCount + 1L);
+                        node.subtreeUpdateCount.addAndGet(-nodeSubtreeUpdateCount + 1L);
                     } else {
-                        node.subtreeUpdateCount.increment();
+                        node.subtreeUpdateCount.incrementAndGet();
                     }
                 }
             } else {
                 if (treeUpdateEpoch == nodeUpdateEpoch || !node.updateEpoch.compareAndSet(nodeUpdateEpoch, treeUpdateEpoch)) {
-                    node.subtreeUpdateCount.increment();
+                    node.subtreeUpdateCount.incrementAndGet();
                 } else {
-                    node.subtreeUpdateCount.add(-nodeSubtreeUpdateCount + 1L);
+                    node.subtreeUpdateCount.addAndGet(-nodeSubtreeUpdateCount + 1L);
                 }
             }
 
@@ -44,7 +44,7 @@ public class ResetByChunksChunk extends Chunk {
                 node = node.parent;
 
                 if (node != null) {
-                    nodeSubtreeUpdateCount = node.subtreeUpdateCount.sum();
+                    nodeSubtreeUpdateCount = node.subtreeUpdateCount.get();
                     nodeUpdateEpoch = node.updateEpoch.get();
                 }
             } else {
@@ -67,7 +67,7 @@ public class ResetByChunksChunk extends Chunk {
             return 0L;
         }
 
-        long nodeSubtreeUpdateCount = node.subtreeUpdateCount.sum();
+        long nodeSubtreeUpdateCount = node.subtreeUpdateCount.get();
 
         return
             node.snapshotNum.get() < tree.snapshotNum ?

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/resetOnSnapshot/ResetOnSnapshotChunk.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/resetOnSnapshot/ResetOnSnapshotChunk.java
@@ -12,22 +12,22 @@ public class ResetOnSnapshotChunk extends Chunk {
 
     @Override
     protected void updateTree(ScaleTreeNode node, boolean snapshotInProgress, long snapshotNum) {
-        long nodeSubtreeUpdateCount = node.subtreeUpdateCount.sum();
+        long nodeSubtreeUpdateCount = node.subtreeUpdateCount.get();
         long nodeUpdateEpoch = node.updateEpoch.get();
         long treeUpdateEpoch = tree.updateEpoch;
 
         while (node != null) {
             if (treeUpdateEpoch == nodeUpdateEpoch || !node.updateEpoch.compareAndSet(nodeUpdateEpoch, treeUpdateEpoch)) {
-                node.subtreeUpdateCount.increment();
+                node.subtreeUpdateCount.incrementAndGet();
             } else {
-                node.subtreeUpdateCount.add(-nodeSubtreeUpdateCount + 1L);
+                node.subtreeUpdateCount.addAndGet(-nodeSubtreeUpdateCount + 1L);
             }
 
             if (node.level > upperLazyTreeLevel) {
                 node = node.parent;
 
                 if (node != null) {
-                    nodeSubtreeUpdateCount = node.subtreeUpdateCount.sum();
+                    nodeSubtreeUpdateCount = node.subtreeUpdateCount.get();
                     nodeUpdateEpoch = node.updateEpoch.get();
                 }
             } else {
@@ -45,6 +45,6 @@ public class ResetOnSnapshotChunk extends Chunk {
         return
             useLazy && node.level < upperLazyTreeLevel ?
             lazySubtreeUpdateCountFor(node) :
-            node.subtreeUpdateCount.sum();
+            node.subtreeUpdateCount.get();
     }
 }

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImpl.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImpl.java
@@ -1,0 +1,70 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+import com.ringcentral.platform.metrics.counter.Counter;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramImpl;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+import com.ringcentral.platform.metrics.histogram.Histogram;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * An implementation of {@link HistogramImpl} that ensures consistent reporting of totals:
+ * {@link Counter.Count} and {@link Histogram.TotalSum}. No other values are reported.
+ * <p>
+ * This implementation guarantees that all updates are fully reflected in the snapshot.
+ * That is, {@link Counter.Count} and {@link Histogram.TotalSum} reported by {@link #snapshot()}
+ * will always correspond to the same set of updates, with no partial or missing data.
+ */
+@SuppressWarnings("ConstantConditions")
+public class ConsistentTotalsHistogramImpl implements HistogramImpl {
+
+    final AtomicLong counter;
+    final AtomicLong totalSumAdder;
+    final AtomicLong updateCounter;
+
+    public ConsistentTotalsHistogramImpl() {
+        this.counter = new AtomicLong();
+        this.totalSumAdder = new AtomicLong();
+        this.updateCounter = new AtomicLong();
+    }
+
+    @Override
+    public void update(long value) {
+        // https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.4.4:
+        //   A synchronization order is a total order over all of the synchronization actions of an execution.
+        //   For each thread t, the synchronization order of the synchronization actions (§17.4.2) in t is consistent with the program order (§17.4.3) of t.
+        //
+        // Therefore, the three writes below are guaranteed to happen in program order.
+        // Since snapshot() reads these fields in reverse order, we cannot observe a torn update if count == updateCount:
+        // after reading updateCount = updateCounter.get(), we must see all prior writes.
+        // At that point, count cannot be greater than updateCount (due to the total synchronization order).
+        // Every update always begins by incrementing the counter.
+        // Consequently, if we do not see a larger counter value in the loop's condition,
+        // the next update has not yet started, and it is safe to proceed with the current values.
+
+        // We must write counter first to ensure the consistency of the totals.
+        counter.incrementAndGet();
+        totalSumAdder.addAndGet(value);
+
+        // We must write updateCounter last.
+        updateCounter.incrementAndGet();
+    }
+
+    @Override
+    public HistogramSnapshot snapshot() {
+        long count;
+        long totalSum;
+        long updateCount;
+
+        do {
+            // We must read updateCounter first.
+            updateCount = updateCounter.get();
+            totalSum = totalSumAdder.get();
+
+            // We must read counter last.
+            count = counter.get();
+        } while (count != updateCount);
+
+        return new TotalsHistogramSnapshot(count, totalSum);
+    }
+}

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImpl.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImpl.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * will always correspond to the same set of updates, with no partial or missing data.
  */
 @SuppressWarnings("ConstantConditions")
-public class ConsistentTotalsHistogramImpl implements HistogramImpl {
+public class ConsistentTotalsHistogramImpl implements TotalsHistogramImpl {
 
     /**
      * Maximum number of iterations the {@link #snapshot()} loop will run.
@@ -77,6 +77,13 @@ public class ConsistentTotalsHistogramImpl implements HistogramImpl {
 
     @Override
     public HistogramSnapshot snapshot() {
+        MutableTotalsHistogramSnapshot snapshot = new MutableTotalsHistogramSnapshot();
+        fillSnapshot(snapshot);
+        return snapshot;
+    }
+
+    @Override
+    public void fillSnapshot(@Nonnull MutableTotalsHistogramSnapshot snapshot) {
         long count;
         long totalSum;
         long updateCount;
@@ -97,7 +104,8 @@ public class ConsistentTotalsHistogramImpl implements HistogramImpl {
             }
         } while (count != updateCount && retryCount < SNAPSHOT_MAX_ITER_COUNT);
 
-        return new TotalsHistogramSnapshot(count, totalSum);
+        snapshot.setCount(count);
+        snapshot.setTotalSum(totalSum);
     }
 
     protected void onSpinWaitImpl() {

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImpl.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImpl.java
@@ -5,6 +5,7 @@ import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramImpl;
 import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
 import com.ringcentral.platform.metrics.histogram.Histogram;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -23,9 +24,17 @@ public class ConsistentTotalsHistogramImpl implements HistogramImpl {
     final AtomicLong updateCounter;
 
     public ConsistentTotalsHistogramImpl() {
-        this.counter = new AtomicLong();
-        this.totalSumAdder = new AtomicLong();
-        this.updateCounter = new AtomicLong();
+        this(new AtomicLong(), new AtomicLong(), new AtomicLong());
+    }
+
+    ConsistentTotalsHistogramImpl(
+        @Nonnull AtomicLong counter,
+        @Nonnull AtomicLong totalSumAdder,
+        @Nonnull AtomicLong updateCounter) {
+
+        this.counter = counter;
+        this.totalSumAdder = totalSumAdder;
+        this.updateCounter = updateCounter;
     }
 
     @Override

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImpl.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImpl.java
@@ -29,21 +29,28 @@ public class ConsistentTotalsHistogramImpl implements TotalsHistogramImpl {
      * <p>The cap - 250k iterations - is far above the expected worst case
      * yet low enough to stop quickly if the system ever enters a pathological state.
      */
-    public static final int SNAPSHOT_MAX_ITER_COUNT = 250_000;
+    public static final int DEFAULT_SNAPSHOT_MAX_ITER_COUNT = 250_000;
 
+    private final int snapshotMaxIterCount;
     private final AtomicLong counter;
     private final AtomicLong totalSumAdder;
     private final AtomicLong updateCounter;
 
     public ConsistentTotalsHistogramImpl() {
-        this(new AtomicLong(), new AtomicLong(), new AtomicLong());
+        this(DEFAULT_SNAPSHOT_MAX_ITER_COUNT);
+    }
+
+    public ConsistentTotalsHistogramImpl(int snapshotMaxIterCount) {
+        this(snapshotMaxIterCount, new AtomicLong(), new AtomicLong(), new AtomicLong());
     }
 
     ConsistentTotalsHistogramImpl(
+        int snapshotMaxIterCount,
         @Nonnull AtomicLong counter,
         @Nonnull AtomicLong totalSumAdder,
         @Nonnull AtomicLong updateCounter) {
 
+        this.snapshotMaxIterCount = snapshotMaxIterCount;
         this.counter = counter;
         this.totalSumAdder = totalSumAdder;
         this.updateCounter = updateCounter;
@@ -102,7 +109,7 @@ public class ConsistentTotalsHistogramImpl implements TotalsHistogramImpl {
                 ++retryCount;
                 onSpinWaitImpl();
             }
-        } while (count != updateCount && retryCount < SNAPSHOT_MAX_ITER_COUNT);
+        } while (count != updateCount && retryCount < snapshotMaxIterCount);
 
         snapshot.setCount(count);
         snapshot.setTotalSum(totalSum);

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/CountHistogramImpl.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/CountHistogramImpl.java
@@ -1,11 +1,11 @@
 package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
 
-import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramImpl;
 import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.atomic.LongAdder;
 
-public class CountHistogramImpl implements HistogramImpl {
+public class CountHistogramImpl implements TotalsHistogramImpl {
 
     private final LongAdder counter;
 
@@ -21,5 +21,10 @@ public class CountHistogramImpl implements HistogramImpl {
     @Override
     public HistogramSnapshot snapshot() {
         return new CountHistogramSnapshot(counter.sum());
+    }
+
+    @Override
+    public void fillSnapshot(@Nonnull MutableTotalsHistogramSnapshot snapshot) {
+        snapshot.setCount(counter.sum());
     }
 }

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/CountHistogramImpl.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/CountHistogramImpl.java
@@ -1,0 +1,25 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramImpl;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+
+import java.util.concurrent.atomic.LongAdder;
+
+public class CountHistogramImpl implements HistogramImpl {
+
+    private final LongAdder counter;
+
+    public CountHistogramImpl() {
+        this.counter = new LongAdder();
+    }
+
+    @Override
+    public void update(long value) {
+        counter.increment();
+    }
+
+    @Override
+    public HistogramSnapshot snapshot() {
+        return new CountHistogramSnapshot(counter.sum());
+    }
+}

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/CountHistogramSnapshot.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/CountHistogramSnapshot.java
@@ -1,0 +1,15 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+public class CountHistogramSnapshot extends HistogramSnapshotAdapter {
+
+    private final long count;
+
+    public CountHistogramSnapshot(long count) {
+        this.count = count;
+    }
+
+    @Override
+    public long count() {
+        return count;
+    }
+}

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/EventuallyConsistentTotalsHistogramImpl.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/EventuallyConsistentTotalsHistogramImpl.java
@@ -1,0 +1,38 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+import com.ringcentral.platform.metrics.counter.Counter;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramImpl;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+import com.ringcentral.platform.metrics.histogram.Histogram;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * An implementation of {@link HistogramImpl} that ensures eventually consistent reporting of totals:
+ * {@link Counter.Count} and {@link Histogram.TotalSum}. No other values are reported.
+ * <p>
+ * Uses {@link LongAdder} for both counting and summing to provide high throughput under contention.
+ * The {@link #snapshot()} method returns the latest {@link Counter.Count} and {@link Histogram.TotalSum},
+ * but under concurrent updates these two values may not reflect the exact same set of operations.
+ */
+public class EventuallyConsistentTotalsHistogramImpl implements HistogramImpl {
+
+    private final LongAdder counter;
+    private final LongAdder totalSumAdder;
+
+    public EventuallyConsistentTotalsHistogramImpl() {
+        this.counter = new LongAdder();
+        this.totalSumAdder = new LongAdder();
+    }
+
+    @Override
+    public void update(long value) {
+        counter.increment();
+        totalSumAdder.add(value);
+    }
+
+    @Override
+    public HistogramSnapshot snapshot() {
+        return new TotalsHistogramSnapshot(counter.sum(), totalSumAdder.sum());
+    }
+}

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/EventuallyConsistentTotalsHistogramImpl.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/EventuallyConsistentTotalsHistogramImpl.java
@@ -5,6 +5,7 @@ import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramImpl;
 import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
 import com.ringcentral.platform.metrics.histogram.Histogram;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
@@ -15,7 +16,7 @@ import java.util.concurrent.atomic.LongAdder;
  * The {@link #snapshot()} method returns the latest {@link Counter.Count} and {@link Histogram.TotalSum},
  * but under concurrent updates these two values may not reflect the exact same set of operations (may differ).
  */
-public class EventuallyConsistentTotalsHistogramImpl implements HistogramImpl {
+public class EventuallyConsistentTotalsHistogramImpl implements TotalsHistogramImpl {
 
     private final LongAdder counter;
     private final LongAdder totalSumAdder;
@@ -34,5 +35,11 @@ public class EventuallyConsistentTotalsHistogramImpl implements HistogramImpl {
     @Override
     public HistogramSnapshot snapshot() {
         return new TotalsHistogramSnapshot(counter.sum(), totalSumAdder.sum());
+    }
+
+    @Override
+    public void fillSnapshot(@Nonnull MutableTotalsHistogramSnapshot snapshot) {
+        snapshot.setCount(counter.sum());
+        snapshot.setTotalSum(totalSumAdder.sum());
     }
 }

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/EventuallyConsistentTotalsHistogramImpl.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/EventuallyConsistentTotalsHistogramImpl.java
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.LongAdder;
  * <p>
  * Uses {@link LongAdder} for both counting and summing to provide high throughput under contention.
  * The {@link #snapshot()} method returns the latest {@link Counter.Count} and {@link Histogram.TotalSum},
- * but under concurrent updates these two values may not reflect the exact same set of operations.
+ * but under concurrent updates these two values may not reflect the exact same set of operations (may differ).
  */
 public class EventuallyConsistentTotalsHistogramImpl implements HistogramImpl {
 

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/HistogramSnapshotAdapter.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/HistogramSnapshotAdapter.java
@@ -1,0 +1,47 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+import com.ringcentral.platform.metrics.histogram.Histogram;
+
+public abstract class HistogramSnapshotAdapter implements HistogramSnapshot {
+
+    @Override
+    public long count() {
+        return NO_VALUE;
+    }
+
+    @Override
+    public long totalSum() {
+        return NO_VALUE;
+    }
+
+    @Override
+    public long min() {
+        return NO_VALUE;
+    }
+
+    @Override
+    public long max() {
+        return NO_VALUE;
+    }
+
+    @Override
+    public double mean() {
+        return NO_VALUE_DOUBLE;
+    }
+
+    @Override
+    public double standardDeviation() {
+        return NO_VALUE_DOUBLE;
+    }
+
+    @Override
+    public double percentileValue(Histogram.Percentile percentile) {
+        return NO_VALUE_DOUBLE;
+    }
+
+    @Override
+    public long bucketSize(Histogram.Bucket bucket) {
+        return NO_VALUE;
+    }
+}

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/MutableTotalsHistogramSnapshot.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/MutableTotalsHistogramSnapshot.java
@@ -1,0 +1,25 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+public class MutableTotalsHistogramSnapshot extends HistogramSnapshotAdapter {
+
+    private long count;
+    private long totalSum;
+
+    @Override
+    public long count() {
+        return count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+
+    @Override
+    public long totalSum() {
+        return totalSum;
+    }
+
+    public void setTotalSum(long totalSum) {
+        this.totalSum = totalSum;
+    }
+}

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/NoOpHistogramImpl.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/NoOpHistogramImpl.java
@@ -1,0 +1,17 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramImpl;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+
+public class NoOpHistogramImpl implements HistogramImpl {
+
+    public static final NoOpHistogramImpl INSTANCE = new NoOpHistogramImpl();
+
+    @Override
+    public void update(long value) {}
+
+    @Override
+    public HistogramSnapshot snapshot() {
+        return NoOpHistogramSnapshot.INSTANCE;
+    }
+}

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/NoOpHistogramSnapshot.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/NoOpHistogramSnapshot.java
@@ -1,0 +1,5 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+public class NoOpHistogramSnapshot extends HistogramSnapshotAdapter {
+    public static final NoOpHistogramSnapshot INSTANCE = new NoOpHistogramSnapshot();
+}

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/TotalSumHistogramImpl.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/TotalSumHistogramImpl.java
@@ -1,0 +1,25 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramImpl;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+
+import java.util.concurrent.atomic.LongAdder;
+
+public class TotalSumHistogramImpl implements HistogramImpl {
+
+    private final LongAdder totalSumAdder;
+
+    public TotalSumHistogramImpl() {
+        this.totalSumAdder = new LongAdder();
+    }
+
+    @Override
+    public void update(long value) {
+        totalSumAdder.add(value);
+    }
+
+    @Override
+    public HistogramSnapshot snapshot() {
+        return new TotalSumHistogramSnapshot(totalSumAdder.sum());
+    }
+}

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/TotalSumHistogramSnapshot.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/TotalSumHistogramSnapshot.java
@@ -1,0 +1,15 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+public class TotalSumHistogramSnapshot extends HistogramSnapshotAdapter {
+
+    private final long totalSum;
+
+    public TotalSumHistogramSnapshot(long totalSum) {
+        this.totalSum = totalSum;
+    }
+
+    @Override
+    public long totalSum() {
+        return totalSum;
+    }
+}

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/TotalsHistogramImpl.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/TotalsHistogramImpl.java
@@ -1,0 +1,24 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramImpl;
+import com.ringcentral.platform.metrics.histogram.Histogram.TotalSum;
+
+import javax.annotation.Nonnull;
+
+import static com.ringcentral.platform.metrics.counter.Counter.Count;
+
+public interface TotalsHistogramImpl extends HistogramImpl {
+
+    /**
+     * Fills the given snapshot with the totals specific to this implementation.
+     * <p>
+     * For example, if the implementation tracks only {@link Count},
+     * it will invoke {@link MutableTotalsHistogramSnapshot#setCount(long)}.
+     * If it tracks both {@link Count} and {@link TotalSum},
+     * it will invoke both {@link MutableTotalsHistogramSnapshot#setCount(long)} and
+     * {@link MutableTotalsHistogramSnapshot#setTotalSum(long)}.
+     *
+     * @param snapshot the snapshot object to be filled
+     */
+    void fillSnapshot(@Nonnull MutableTotalsHistogramSnapshot snapshot);
+}

--- a/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/TotalsHistogramSnapshot.java
+++ b/metrics-facade-default-impl/src/main/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/TotalsHistogramSnapshot.java
@@ -1,0 +1,22 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+public class TotalsHistogramSnapshot extends HistogramSnapshotAdapter {
+
+    private final long count;
+    private final long totalSum;
+
+    public TotalsHistogramSnapshot(long count, long totalSum) {
+        this.count = count;
+        this.totalSum = totalSum;
+    }
+
+    @Override
+    public long count() {
+        return count;
+    }
+
+    @Override
+    public long totalSum() {
+        return totalSum;
+    }
+}

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/AbstractHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/AbstractHistogramImplTest.java
@@ -1,0 +1,31 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram;
+
+import com.ringcentral.platform.metrics.defaultImpl.histogram.configs.TotalsMeasurementType;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.totals.*;
+import com.ringcentral.platform.metrics.measurables.Measurable;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import static com.ringcentral.platform.metrics.counter.Counter.COUNT;
+import static com.ringcentral.platform.metrics.defaultImpl.histogram.configs.TotalsMeasurementType.*;
+import static com.ringcentral.platform.metrics.histogram.Histogram.TOTAL_SUM;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public abstract class AbstractHistogramImplTest<H extends AbstractHistogramImpl> {
+
+    protected abstract H makeHistogramImpl(@Nonnull TotalsMeasurementType totalsMeasurementType, @Nonnull Measurable... measurables);
+
+    @Test
+    public void totalsOnly() {
+        assertThat(makeHistogramImpl(CONSISTENT, COUNT).parent(), is(instanceOf(CountHistogramImpl.class)));
+        assertThat(makeHistogramImpl(EVENTUALLY_CONSISTENT, COUNT).parent(), is(instanceOf(CountHistogramImpl.class)));
+
+        assertThat(makeHistogramImpl(CONSISTENT, TOTAL_SUM).parent(), is(instanceOf(TotalSumHistogramImpl.class)));
+        assertThat(makeHistogramImpl(EVENTUALLY_CONSISTENT, TOTAL_SUM).parent(), is(instanceOf(TotalSumHistogramImpl.class)));
+
+        assertThat(makeHistogramImpl(CONSISTENT, COUNT, TOTAL_SUM).parent(), is(instanceOf(ConsistentTotalsHistogramImpl.class)));
+        assertThat(makeHistogramImpl(EVENTUALLY_CONSISTENT, COUNT, TOTAL_SUM).parent(), is(instanceOf(EventuallyConsistentTotalsHistogramImpl.class)));
+    }
+}

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/AbstractHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/AbstractHistogramImplTest.java
@@ -27,5 +27,8 @@ public abstract class AbstractHistogramImplTest<H extends AbstractHistogramImpl>
 
         assertThat(makeHistogramImpl(CONSISTENT, COUNT, TOTAL_SUM).parent(), is(instanceOf(ConsistentTotalsHistogramImpl.class)));
         assertThat(makeHistogramImpl(EVENTUALLY_CONSISTENT, COUNT, TOTAL_SUM).parent(), is(instanceOf(EventuallyConsistentTotalsHistogramImpl.class)));
+
+        // no Measurables
+        assertThat(makeHistogramImpl(EVENTUALLY_CONSISTENT).parent(), is(instanceOf(NoOpHistogramImpl.class)));
     }
 }

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/hdr/neverReset/NeverResetHdrHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/hdr/neverReset/NeverResetHdrHistogramImplTest.java
@@ -1,9 +1,14 @@
 package com.ringcentral.platform.metrics.defaultImpl.histogram.hdr.neverReset;
 
+import com.ringcentral.platform.metrics.defaultImpl.histogram.AbstractHistogramImplTest;
 import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
-import com.ringcentral.platform.metrics.test.time.*;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.configs.TotalsMeasurementType;
+import com.ringcentral.platform.metrics.measurables.Measurable;
+import com.ringcentral.platform.metrics.test.time.TestScheduledExecutorService;
+import com.ringcentral.platform.metrics.test.time.TestTimeNanosProvider;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -14,10 +19,18 @@ import static java.lang.Math.sqrt;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class NeverResetHdrHistogramImplTest {
+public class NeverResetHdrHistogramImplTest extends AbstractHistogramImplTest<NeverResetHdrHistogramImpl> {
 
     static final TestTimeNanosProvider timeNanosProvider = new TestTimeNanosProvider();
     static final ScheduledExecutorService executor = new TestScheduledExecutorService(timeNanosProvider);
+
+    @Override
+    protected NeverResetHdrHistogramImpl makeHistogramImpl(@Nonnull TotalsMeasurementType totalsMeasurementType, @Nonnull Measurable... measurables) {
+        return new NeverResetHdrHistogramImpl(
+            hdrImpl().neverReset().totals(totalsMeasurementType).build(),
+            Set.of(measurables),
+            executor);
+    }
 
     @Test
     public void allMeasurables_NeverResetBuckets() {

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/hdr/resetByChunks/ResetByChunksHdrHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/hdr/resetByChunks/ResetByChunksHdrHistogramImplTest.java
@@ -1,9 +1,13 @@
 package com.ringcentral.platform.metrics.defaultImpl.histogram.hdr.resetByChunks;
 
+import com.ringcentral.platform.metrics.defaultImpl.histogram.AbstractHistogramImplTest;
 import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.configs.TotalsMeasurementType;
+import com.ringcentral.platform.metrics.measurables.Measurable;
 import com.ringcentral.platform.metrics.test.time.*;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
@@ -15,7 +19,7 @@ import static java.lang.Math.sqrt;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ResetByChunksHdrHistogramImplTest {
+public class ResetByChunksHdrHistogramImplTest extends AbstractHistogramImplTest<ResetByChunksHdrHistogramImpl> {
 
     static final int CHUNK_COUNT = 5;
     static final int ALL_CHUNKS_RESET_PERIOD_MS = 1000 * CHUNK_COUNT;
@@ -23,6 +27,14 @@ public class ResetByChunksHdrHistogramImplTest {
     static final TestTimeNanosProvider timeNanosProvider = new TestTimeNanosProvider();
     static final TestTimeMsProvider timeMsProvider = new TestTimeMsProvider(timeNanosProvider);
     static final ScheduledExecutorService executor = new TestScheduledExecutorService(timeNanosProvider);
+
+    @Override
+    protected ResetByChunksHdrHistogramImpl makeHistogramImpl(@Nonnull TotalsMeasurementType totalsMeasurementType, @Nonnull Measurable... measurables) {
+        return new ResetByChunksHdrHistogramImpl(
+            hdrImpl().resetByChunks().totals(totalsMeasurementType).build(),
+            Set.of(measurables),
+            executor);
+    }
 
     @Test
     public void allMeasurables_NeverResetBuckets() {

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/hdr/resetOnSnapshot/ResetOnSnapshotHdrHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/hdr/resetOnSnapshot/ResetOnSnapshotHdrHistogramImplTest.java
@@ -1,9 +1,14 @@
 package com.ringcentral.platform.metrics.defaultImpl.histogram.hdr.resetOnSnapshot;
 
+import com.ringcentral.platform.metrics.defaultImpl.histogram.AbstractHistogramImplTest;
 import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
-import com.ringcentral.platform.metrics.test.time.*;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.configs.TotalsMeasurementType;
+import com.ringcentral.platform.metrics.measurables.Measurable;
+import com.ringcentral.platform.metrics.test.time.TestScheduledExecutorService;
+import com.ringcentral.platform.metrics.test.time.TestTimeNanosProvider;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -15,10 +20,18 @@ import static java.lang.Math.sqrt;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ResetOnSnapshotHdrHistogramImplTest {
+public class ResetOnSnapshotHdrHistogramImplTest extends AbstractHistogramImplTest<ResetOnSnapshotHdrHistogramImpl> {
 
     static final TestTimeNanosProvider timeNanosProvider = new TestTimeNanosProvider();
     static final ScheduledExecutorService executor = new TestScheduledExecutorService(timeNanosProvider);
+
+    @Override
+    protected ResetOnSnapshotHdrHistogramImpl makeHistogramImpl(@Nonnull TotalsMeasurementType totalsMeasurementType, @Nonnull Measurable... measurables) {
+        return new ResetOnSnapshotHdrHistogramImpl(
+            hdrImpl().resetOnSnapshot().totals(totalsMeasurementType).build(),
+            Set.of(measurables),
+            executor);
+    }
 
     @Test
     public void allMeasurables_NeverResetBuckets() {

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/internal/ScaleTreeTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/internal/ScaleTreeTest.java
@@ -50,7 +50,7 @@ public class ScaleTreeTest {
             true,
             0L);
 
-        SubtreeUpdateCountProvider subtreeUpdateCountProvider = node -> node.subtreeUpdateCount.sum();
+        SubtreeUpdateCountProvider subtreeUpdateCountProvider = node -> node.subtreeUpdateCount.get();
         long[] bucketSizes = tree.bucketSizes(bucketUpperBounds, subtreeUpdateCountProvider);
 
         for (long bucketSize : bucketSizes) {
@@ -58,14 +58,14 @@ public class ScaleTreeTest {
         }
 
         tree.traversePostOrder(node -> {
-            node.subtreeUpdateCount.increment();
+            node.subtreeUpdateCount.incrementAndGet();
 
             if (node.left != null) {
-                node.subtreeUpdateCount.add(node.left.subtreeUpdateCount.sum());
+                node.subtreeUpdateCount.addAndGet(node.left.subtreeUpdateCount.get());
             }
 
             if (node.right != null) {
-                node.subtreeUpdateCount.add(node.right.subtreeUpdateCount.sum());
+                node.subtreeUpdateCount.addAndGet(node.right.subtreeUpdateCount.get());
             }
         });
 
@@ -82,10 +82,10 @@ public class ScaleTreeTest {
         assertThat(bucketSizes[8], is(9L));
         assertThat(bucketSizes[9], is(10L));
         assertThat(bucketSizes[10], is(11L));
-        assertThat(tree.bucketSizes(new long[] { -1L }, node -> node.subtreeUpdateCount.sum())[0], is(0L));
-        assertThat(tree.bucketSizes(new long[] { 250L }, node -> node.subtreeUpdateCount.sum())[0], is(10L));
+        assertThat(tree.bucketSizes(new long[] { -1L }, node -> node.subtreeUpdateCount.get())[0], is(0L));
+        assertThat(tree.bucketSizes(new long[] { 250L }, node -> node.subtreeUpdateCount.get())[0], is(10L));
 
-        tree.traversePostOrder(node -> node.subtreeUpdateCount.reset());
+        tree.traversePostOrder(node -> node.subtreeUpdateCount.set(0));
         bucketSizes = tree.bucketSizes(bucketUpperBounds, subtreeUpdateCountProvider);
 
         for (long bucketSize : bucketSizes) {
@@ -103,21 +103,21 @@ public class ScaleTreeTest {
             0L);
 
         tree.traversePostOrder(node -> {
-            node.subtreeUpdateCount.increment();
+            node.subtreeUpdateCount.incrementAndGet();
 
             if (node.left != null) {
-                node.subtreeUpdateCount.add(node.left.subtreeUpdateCount.sum());
+                node.subtreeUpdateCount.addAndGet(node.left.subtreeUpdateCount.get());
             }
 
             if (node.right != null) {
-                node.subtreeUpdateCount.add(node.right.subtreeUpdateCount.sum());
+                node.subtreeUpdateCount.addAndGet(node.right.subtreeUpdateCount.get());
             }
         });
 
-        assertThat(tree.bucketSizes(new long[] { -1L }, node -> node.subtreeUpdateCount.sum())[0], is(0L));
-        assertThat(tree.bucketSizes(new long[] { 50L }, node -> node.subtreeUpdateCount.sum())[0], is(6L));
-        assertThat(tree.bucketSizes(new long[] { 90L }, node -> node.subtreeUpdateCount.sum())[0], is(10L));
-        assertThat(tree.bucketSizes(new long[] { 125L }, node -> node.subtreeUpdateCount.sum())[0], is(10L));
-        assertThat(tree.bucketSizes(new long[] { Long.MAX_VALUE }, node -> node.subtreeUpdateCount.sum())[0], is(10L));
+        assertThat(tree.bucketSizes(new long[] { -1L }, node -> node.subtreeUpdateCount.get())[0], is(0L));
+        assertThat(tree.bucketSizes(new long[] { 50L }, node -> node.subtreeUpdateCount.get())[0], is(6L));
+        assertThat(tree.bucketSizes(new long[] { 90L }, node -> node.subtreeUpdateCount.get())[0], is(10L));
+        assertThat(tree.bucketSizes(new long[] { 125L }, node -> node.subtreeUpdateCount.get())[0], is(10L));
+        assertThat(tree.bucketSizes(new long[] { Long.MAX_VALUE }, node -> node.subtreeUpdateCount.get())[0], is(10L));
     }
 }

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/neverReset/NeverResetScaleHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/neverReset/NeverResetScaleHistogramImplTest.java
@@ -1,10 +1,15 @@
 package com.ringcentral.platform.metrics.defaultImpl.histogram.scale.neverReset;
 
+import com.ringcentral.platform.metrics.defaultImpl.histogram.AbstractHistogramImplTest;
 import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.configs.TotalsMeasurementType;
+import com.ringcentral.platform.metrics.measurables.Measurable;
 import com.ringcentral.platform.metrics.scale.LinearScaleBuilder;
-import com.ringcentral.platform.metrics.test.time.*;
+import com.ringcentral.platform.metrics.test.time.TestScheduledExecutorService;
+import com.ringcentral.platform.metrics.test.time.TestTimeNanosProvider;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -16,11 +21,19 @@ import static java.lang.Math.sqrt;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class NeverResetScaleHistogramImplTest {
+public class NeverResetScaleHistogramImplTest extends AbstractHistogramImplTest<NeverResetScaleHistogramImpl> {
 
     static final LinearScaleBuilder SCALE_1 = linearScale().steps(1, 10000);
     static final TestTimeNanosProvider timeNanosProvider = new TestTimeNanosProvider();
     static final ScheduledExecutorService executor = new TestScheduledExecutorService(timeNanosProvider);
+
+    @Override
+    protected NeverResetScaleHistogramImpl makeHistogramImpl(@Nonnull TotalsMeasurementType totalsMeasurementType, @Nonnull Measurable... measurables) {
+        return new NeverResetScaleHistogramImpl(
+            scaleImpl().neverReset().totals(totalsMeasurementType).build(),
+            Set.of(measurables),
+            executor);
+    }
 
     @Test
     public void scale_1_AllMeasurables_NeverResetBuckets() {

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/resetByChunks/ResetByChunksScaleHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/resetByChunks/ResetByChunksScaleHistogramImplTest.java
@@ -1,21 +1,22 @@
 package com.ringcentral.platform.metrics.defaultImpl.histogram.scale.resetByChunks;
 
+import com.ringcentral.platform.metrics.defaultImpl.histogram.AbstractHistogramImplTest;
 import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.configs.TotalsMeasurementType;
+import com.ringcentral.platform.metrics.measurables.Measurable;
 import com.ringcentral.platform.metrics.scale.LinearScaleBuilder;
 import com.ringcentral.platform.metrics.scale.Scale;
-import com.ringcentral.platform.metrics.test.time.TestScheduledExecutorService;
-import com.ringcentral.platform.metrics.test.time.TestTimeMsProvider;
-import com.ringcentral.platform.metrics.test.time.TestTimeNanosProvider;
+import com.ringcentral.platform.metrics.test.time.*;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static com.ringcentral.platform.metrics.counter.Counter.COUNT;
-import static com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot.NO_VALUE;
-import static com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot.NO_VALUE_DOUBLE;
+import static com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot.*;
 import static com.ringcentral.platform.metrics.defaultImpl.histogram.scale.configs.ScaleHistogramImplConfigBuilder.scaleImpl;
 import static com.ringcentral.platform.metrics.histogram.Histogram.*;
 import static com.ringcentral.platform.metrics.scale.LinearScaleBuilder.linearScale;
@@ -26,7 +27,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ResetByChunksScaleHistogramImplTest {
+public class ResetByChunksScaleHistogramImplTest extends AbstractHistogramImplTest<ResetByChunksScaleHistogramImpl> {
 
     static final int CHUNK_COUNT = 5;
     public static final long CHUNK_RESET_PERIOD_MS = 1000L;
@@ -42,6 +43,14 @@ public class ResetByChunksScaleHistogramImplTest {
     static final TestTimeNanosProvider timeNanosProvider = new TestTimeNanosProvider();
     static final TestTimeMsProvider timeMsProvider = new TestTimeMsProvider(timeNanosProvider);
     static final ScheduledExecutorService executor = new TestScheduledExecutorService(timeNanosProvider);
+
+    @Override
+    protected ResetByChunksScaleHistogramImpl makeHistogramImpl(@Nonnull TotalsMeasurementType totalsMeasurementType, @Nonnull Measurable... measurables) {
+        return new ResetByChunksScaleHistogramImpl(
+            scaleImpl().resetByChunks().totals(totalsMeasurementType).build(),
+            Set.of(measurables),
+            executor);
+    }
 
     @Test
     public void scale_1_AllMeasurables_NeverResetBuckets() {

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/resetOnSnapshot/ResetOnSnapshotScaleHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/scale/resetOnSnapshot/ResetOnSnapshotScaleHistogramImplTest.java
@@ -1,10 +1,15 @@
 package com.ringcentral.platform.metrics.defaultImpl.histogram.scale.resetOnSnapshot;
 
+import com.ringcentral.platform.metrics.defaultImpl.histogram.AbstractHistogramImplTest;
 import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.configs.TotalsMeasurementType;
+import com.ringcentral.platform.metrics.measurables.Measurable;
 import com.ringcentral.platform.metrics.scale.LinearScaleBuilder;
-import com.ringcentral.platform.metrics.test.time.*;
+import com.ringcentral.platform.metrics.test.time.TestScheduledExecutorService;
+import com.ringcentral.platform.metrics.test.time.TestTimeNanosProvider;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -17,11 +22,19 @@ import static java.lang.Math.sqrt;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ResetOnSnapshotScaleHistogramImplTest {
+public class ResetOnSnapshotScaleHistogramImplTest extends AbstractHistogramImplTest<ResetOnSnapshotScaleHistogramImpl> {
 
     static final LinearScaleBuilder SCALE_1 = linearScale().steps(1, 100);
     static final TestTimeNanosProvider timeNanosProvider = new TestTimeNanosProvider();
     static final ScheduledExecutorService executor = new TestScheduledExecutorService(timeNanosProvider);
+
+    @Override
+    protected ResetOnSnapshotScaleHistogramImpl makeHistogramImpl(@Nonnull TotalsMeasurementType totalsMeasurementType, @Nonnull Measurable... measurables) {
+        return new ResetOnSnapshotScaleHistogramImpl(
+            scaleImpl().resetOnSnapshot().totals(totalsMeasurementType).build(),
+            Set.of(measurables),
+            executor);
+    }
 
     @Test
     public void scale_1_AllMeasurables_NeverResetBuckets() {

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/AbstractTotalsHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/AbstractTotalsHistogramImplTest.java
@@ -1,0 +1,60 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramImpl;
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+import org.junit.Test;
+
+import static com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot.*;
+import static com.ringcentral.platform.metrics.histogram.Histogram.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public abstract class AbstractTotalsHistogramImplTest<H extends HistogramImpl> {
+
+    protected abstract H makeHistogramImpl();
+
+    @Test
+    public void updateAndSnapshot() {
+        // given
+        HistogramImpl histogram = makeHistogramImpl();
+
+        // then
+        checkSnapshot(histogram, 0, 0);
+
+        // when
+        histogram.update(0);
+
+        // then
+        checkSnapshot(histogram, 1, 0);
+
+        // when
+        histogram.update(1);
+
+        // then
+        checkSnapshot(histogram, 2, 1);
+
+        // when
+        histogram.update(2);
+
+        // then
+        checkSnapshot(histogram, 3, 3);
+
+        // when
+        histogram.update(5);
+
+        // then
+        checkSnapshot(histogram, 4, 8);
+    }
+
+    void checkSnapshot(HistogramImpl histogram, long expectedCount, long expectedTotalSum) {
+        HistogramSnapshot snapshot = histogram.snapshot();
+        assertThat(snapshot.count(), is(expectedCount));
+        assertThat(snapshot.totalSum(), is(expectedTotalSum));
+        assertThat(snapshot.min(), is(NO_VALUE));
+        assertThat(snapshot.max(), is(NO_VALUE));
+        assertThat(snapshot.mean(), is(NO_VALUE_DOUBLE));
+        assertThat(snapshot.standardDeviation(), is(NO_VALUE_DOUBLE));
+        assertThat(snapshot.percentileValue(PERCENTILE_50), is(NO_VALUE_DOUBLE));
+        assertThat(snapshot.bucketSize(MS_1_BUCKET), is(NO_VALUE));
+    }
+}

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImplTest.java
@@ -7,6 +7,7 @@ import org.mockito.stubbing.Answer;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.ringcentral.platform.metrics.defaultImpl.histogram.totals.ConsistentTotalsHistogramImpl.DEFAULT_SNAPSHOT_MAX_ITER_COUNT;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
@@ -48,7 +49,7 @@ public class ConsistentTotalsHistogramImplTest extends AbstractTotalsHistogramIm
         }).when(counter).get();
 
         doAnswer(inv -> parentCounter.incrementAndGet()).when(counter).incrementAndGet();
-        ConsistentTotalsHistogramImpl histogram = new ConsistentTotalsHistogramImpl(counter, totalSumAdder, updateCounter);
+        ConsistentTotalsHistogramImpl histogram = new ConsistentTotalsHistogramImpl(DEFAULT_SNAPSHOT_MAX_ITER_COUNT, counter, totalSumAdder, updateCounter);
 
         // when
         histogram.update(10);
@@ -60,5 +61,36 @@ public class ConsistentTotalsHistogramImplTest extends AbstractTotalsHistogramIm
         verify(counter, times(2)).get();
         verify(totalSumAdder, times(2)).get();
         verify(updateCounter, times(2)).get();
+    }
+
+    @Test
+    public void snapshotIterCountLimit() {
+        // given
+        AtomicLong parentCounter = new AtomicLong();
+        AtomicLong counter = spy(AtomicLong.class);
+        AtomicLong totalSumAdder = spy(new AtomicLong());
+        AtomicLong updateCounter = spy(new AtomicLong());
+
+        // makes snapshot()'s consistency check fail
+        doAnswer((Answer<Object>)inv -> {
+            long nextCount = parentCounter.incrementAndGet();
+            totalSumAdder.addAndGet(5);
+            updateCounter.incrementAndGet();
+            return nextCount;
+        }).when(counter).get();
+
+        doAnswer(inv -> parentCounter.incrementAndGet()).when(counter).incrementAndGet();
+        ConsistentTotalsHistogramImpl histogram = new ConsistentTotalsHistogramImpl(3, counter, totalSumAdder, updateCounter);
+
+        // when
+        histogram.update(10);
+
+        // then: these values are yielded in the second iteration of the snapshot() method's loop.
+        HistogramSnapshot snapshot = histogram.snapshot();
+        assertThat(snapshot.count(), is(3L + 1L));
+        assertThat(snapshot.totalSum(), is((3L + 1L) * 5)); // doAnswer: totalSumAdder.addAndGet(5)
+        verify(counter, times(3)).get();
+        verify(totalSumAdder, times(3)).get();
+        verify(updateCounter, times(3)).get();
     }
 }

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImplTest.java
@@ -1,9 +1,64 @@
 package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
 
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
 public class ConsistentTotalsHistogramImplTest extends AbstractTotalsHistogramImplTest<ConsistentTotalsHistogramImpl> {
 
     @Override
     protected ConsistentTotalsHistogramImpl makeHistogramImpl() {
         return new ConsistentTotalsHistogramImpl();
+    }
+
+    /**
+     * Basic logic test without real concurrency.
+     */
+    @Test
+    public void basicConsistency() {
+        // given
+        AtomicLong parentCounter = new AtomicLong();
+        AtomicLong counter = spy(AtomicLong.class);
+        AtomicLong totalSumAdder = spy(new AtomicLong());
+        AtomicLong updateCounter = spy(new AtomicLong());
+
+        doAnswer(new Answer<>() {
+
+            private boolean firstCall = true;
+
+            @Override
+            public Long answer(InvocationOnMock inv) {
+                if (firstCall) {
+                    firstCall = false;
+                    long nextCount = parentCounter.incrementAndGet();
+                    totalSumAdder.addAndGet(5);
+                    updateCounter.incrementAndGet();
+                    return nextCount;
+                } else {
+                    return parentCounter.get();
+                }
+            };
+        }).when(counter).get();
+
+        doAnswer(inv -> parentCounter.incrementAndGet()).when(counter).incrementAndGet();
+        ConsistentTotalsHistogramImpl histogram = new ConsistentTotalsHistogramImpl(counter, totalSumAdder, updateCounter);
+
+        // when
+        histogram.update(10);
+
+        // then: these values are yielded in the second iteration of the snapshot() method's loop.
+        HistogramSnapshot snapshot = histogram.snapshot();
+        assertThat(snapshot.count(), is(2L));
+        assertThat(snapshot.totalSum(), is(10L + 5L)); // doAnswer: totalSumAdder.addAndGet(5)
+        verify(counter, times(2)).get();
+        verify(totalSumAdder, times(2)).get();
+        verify(updateCounter, times(2)).get();
     }
 }

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/ConsistentTotalsHistogramImplTest.java
@@ -1,0 +1,9 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+public class ConsistentTotalsHistogramImplTest extends AbstractTotalsHistogramImplTest<ConsistentTotalsHistogramImpl> {
+
+    @Override
+    protected ConsistentTotalsHistogramImpl makeHistogramImpl() {
+        return new ConsistentTotalsHistogramImpl();
+    }
+}

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/CountHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/CountHistogramImplTest.java
@@ -1,0 +1,57 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+import org.junit.Test;
+
+import static com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot.*;
+import static com.ringcentral.platform.metrics.histogram.Histogram.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class CountHistogramImplTest {
+
+    @Test
+    public void updateAndSnapshot() {
+        // given
+        CountHistogramImpl histogram = new CountHistogramImpl();
+
+        // then
+        checkSnapshot(histogram, 0);
+
+        // when
+        histogram.update(0);
+
+        // then
+        checkSnapshot(histogram, 1);
+
+        // when
+        histogram.update(1);
+
+        // then
+        checkSnapshot(histogram, 2);
+
+        // when
+        histogram.update(2);
+
+        // then
+        checkSnapshot(histogram, 3);
+
+        // when
+        histogram.update(5);
+
+        // then
+        checkSnapshot(histogram, 4);
+    }
+
+    void checkSnapshot(CountHistogramImpl histogram, long expectedCount) {
+        HistogramSnapshot snapshot = histogram.snapshot();
+        assertThat(snapshot.count(), is(expectedCount));
+        assertThat(snapshot.totalSum(), is(NO_VALUE));
+        assertThat(snapshot.min(), is(NO_VALUE));
+        assertThat(snapshot.max(), is(NO_VALUE));
+        assertThat(snapshot.mean(), is(NO_VALUE_DOUBLE));
+        assertThat(snapshot.standardDeviation(), is(NO_VALUE_DOUBLE));
+        assertThat(snapshot.percentileValue(PERCENTILE_50), is(NO_VALUE_DOUBLE));
+        assertThat(snapshot.bucketSize(MS_1_BUCKET), is(NO_VALUE));
+    }
+}

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/EventuallyConsistentTotalsHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/EventuallyConsistentTotalsHistogramImplTest.java
@@ -1,0 +1,9 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+public class EventuallyConsistentTotalsHistogramImplTest extends AbstractTotalsHistogramImplTest<EventuallyConsistentTotalsHistogramImpl> {
+
+    @Override
+    protected EventuallyConsistentTotalsHistogramImpl makeHistogramImpl() {
+        return new EventuallyConsistentTotalsHistogramImpl();
+    }
+}

--- a/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/TotalSumHistogramImplTest.java
+++ b/metrics-facade-default-impl/src/test/java/com/ringcentral/platform/metrics/defaultImpl/histogram/totals/TotalSumHistogramImplTest.java
@@ -1,0 +1,57 @@
+package com.ringcentral.platform.metrics.defaultImpl.histogram.totals;
+
+import com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot;
+import org.junit.Test;
+
+import static com.ringcentral.platform.metrics.defaultImpl.histogram.HistogramSnapshot.*;
+import static com.ringcentral.platform.metrics.histogram.Histogram.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TotalSumHistogramImplTest {
+
+    @Test
+    public void updateAndSnapshot() {
+        // given
+        TotalSumHistogramImpl histogram = new TotalSumHistogramImpl();
+
+        // then
+        checkSnapshot(histogram, 0);
+
+        // when
+        histogram.update(0);
+
+        // then
+        checkSnapshot(histogram, 0);
+
+        // when
+        histogram.update(1);
+
+        // then
+        checkSnapshot(histogram, 1);
+
+        // when
+        histogram.update(2);
+
+        // then
+        checkSnapshot(histogram, 3);
+
+        // when
+        histogram.update(5);
+
+        // then
+        checkSnapshot(histogram, 8);
+    }
+
+    void checkSnapshot(TotalSumHistogramImpl histogram, long expectedTotalSum) {
+        HistogramSnapshot snapshot = histogram.snapshot();
+        assertThat(snapshot.count(), is(NO_VALUE));
+        assertThat(snapshot.totalSum(), is(expectedTotalSum));
+        assertThat(snapshot.min(), is(NO_VALUE));
+        assertThat(snapshot.max(), is(NO_VALUE));
+        assertThat(snapshot.mean(), is(NO_VALUE_DOUBLE));
+        assertThat(snapshot.standardDeviation(), is(NO_VALUE_DOUBLE));
+        assertThat(snapshot.percentileValue(PERCENTILE_50), is(NO_VALUE_DOUBLE));
+        assertThat(snapshot.bucketSize(MS_1_BUCKET), is(NO_VALUE));
+    }
+}


### PR DESCRIPTION
The main changes:

- ConsistentTotalsHistogramImpl: replaced `LongAdder` with `AtomicLong`.
- TotalsHistograms have been split into specialized versions (count, total sum, count + total sum) for clarity and efficiency.
- ScaleHistogram internal classes: replaced `LongAdder` with `AtomicLong`. Although there may not be any actual bugs, the `LongAdder` should not be used as a concurrency primitive (per its JavaDoc), and reasoning about concurrency with `LongAdder` is difficult.
- Added comments and some unit tests.

Actually, given the LongAdder's internals, it seems to be correct as well (for ConsistentTotalsHistogramImpl) - but according to its contract, it isn't.
If we add `LockSupport.parkNanos(TimeUnit.MICROSECONDS.toNanos(1));` to the benchmark for both operations, we get a very heavy (unrealistically heavy) load compared to anything likely to happen in practice, and under that load the results are almost identical:

```
// AtomicLong
//    Benchmark                                                                Mode  Cnt  Score   Error   Units
//    ConsistentTotalsBasicConsistencyCheckBenchmark.writeReadNoDelays        thrpt    5  1.800 ± 0.213  ops/us
//    ConsistentTotalsBasicConsistencyCheckBenchmark.writeReadNoDelays:read   thrpt    5  0.596 ± 0.073  ops/us
//    ConsistentTotalsBasicConsistencyCheckBenchmark.writeReadNoDelays:write  thrpt    5  1.204 ± 0.140  ops/us
//    ConsistentTotalsBasicConsistencyCheckBenchmark.writeReadNoDelays         avgt    5  6.471 ± 0.261   us/op
//    ConsistentTotalsBasicConsistencyCheckBenchmark.writeReadNoDelays:read    avgt    5  6.529 ± 0.286   us/op
//    ConsistentTotalsBasicConsistencyCheckBenchmark.writeReadNoDelays:write   avgt    5  6.441 ± 0.250   us/op

// LongAdder
//    Benchmark                                                                Mode  Cnt  Score   Error   Units
//    ConsistentTotalsBasicConsistencyCheckBenchmark.writeReadNoDelays        thrpt    5  1.685 ± 0.114  ops/us
//    ConsistentTotalsBasicConsistencyCheckBenchmark.writeReadNoDelays:read   thrpt    5  0.568 ± 0.037  ops/us
//    ConsistentTotalsBasicConsistencyCheckBenchmark.writeReadNoDelays:write  thrpt    5  1.117 ± 0.078  ops/us
//    ConsistentTotalsBasicConsistencyCheckBenchmark.writeReadNoDelays         avgt    5  7.174 ± 0.641   us/op
//    ConsistentTotalsBasicConsistencyCheckBenchmark.writeReadNoDelays:read    avgt    5  7.044 ± 0.636   us/op
//    ConsistentTotalsBasicConsistencyCheckBenchmark.writeReadNoDelays:write   avgt    5  7.239 ± 0.643   us/op
```

So it has been decided to move to the AL version. Additionally, it's much easier to reason about.